### PR TITLE
Scene: add binding for findObjectByName(char*)

### DIFF
--- a/src/RamsesObject.cpp
+++ b/src/RamsesObject.cpp
@@ -1,0 +1,37 @@
+
+//  -------------------------------------------------------------------------
+//  Copyright (C) 2019 Daniel Werner Lima Souza de Almeida
+//  -------------------------------------------------------------------------
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//  -------------------------------------------------------------------------
+
+
+#include "ramses-client-api/RamsesObject.h"
+#include "ramses-client-api/RamsesObjectTypes.h"
+
+#include "ramses-python/RamsesObject.h"
+
+namespace RamsesPython
+{
+    RamsesObject::RamsesObject(ramses::RamsesObject* ramsesObject) : m_object(ramsesObject)
+    {
+    };
+
+    std::string RamsesObject::getName()
+    {
+        const char* name = m_object->getName();
+        return std::string{name};
+    }
+
+    bool RamsesObject::isOfType(ramses::ERamsesObjectType type) const
+    {
+        return m_object->isOfType(type);
+    }
+
+    ramses::ERamsesObjectType RamsesObject::getType() const
+    {
+        return m_object->getType();
+    }
+}

--- a/src/RamsesPython.cpp
+++ b/src/RamsesPython.cpp
@@ -1,5 +1,5 @@
 //  -------------------------------------------------------------------------
-//  Copyright (C) 2019 BMW AG
+//  Copyright (C) 2019 BMW AG, Daniel Werner Lima Souza de Almeida
 //  -------------------------------------------------------------------------
 //  This Source Code Form is subject to the terms of the Mozilla Public
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -141,6 +141,12 @@ PYBIND11_MODULE(RamsesPython, m)
         .def("createGeometry", &Scene::createGeometry)
         .def("saveToFiles", &Scene::saveToFiles)
         .def("getValidationReport", &Scene::getValidationReport)
+        .def("findObjectByName", &Scene::findObjectByName)
     ;
-}
 
+    class_<RamsesObject>(m, "RamsesObject")
+            .def("getName", &RamsesObject::getName)
+            .def("isOfType", &RamsesObject::isOfType)
+            .def("getType", &RamsesObject::getType)
+            ;
+}

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -1,10 +1,11 @@
 //  -------------------------------------------------------------------------
-//  Copyright (C) 2019 BMW AG
+//  Copyright (C) 2019 BMW AG, Daniel Werner Lima Souza de Almeida
 //  -------------------------------------------------------------------------
 //  This Source Code Form is subject to the terms of the Mozilla Public
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //  -------------------------------------------------------------------------
+
 
 #include "ramses-python/Scene.h"
 #include "ramses-python/Resource.h"
@@ -153,12 +154,12 @@ namespace RamsesPython
         // TODO fix ramses serialization API
         ramses::ResourceFileDescriptionSet resourceFileSet;
         ramses::ResourceFileDescription resourceFile(resourcesFile.c_str());
-        
+
         for(const auto& resource : m_resources)
             resourceFile.add(resource);
-        
+
         resourceFileSet.add(resourceFile);
-        
+
         m_scene->flush();
         m_client->saveSceneToFile(*m_scene, sceneFile.c_str(), resourceFileSet, compress);
     }
@@ -174,5 +175,9 @@ namespace RamsesPython
 
         return "";
     }
-}
 
+    RamsesPython::RamsesObject Scene::findObjectByName(const char* name)
+    {
+        return RamsesPython::RamsesObject {m_scene->findObjectByName(name)};
+    }
+}

--- a/src/include/ramses-python/RamsesObject.h
+++ b/src/include/ramses-python/RamsesObject.h
@@ -1,0 +1,33 @@
+
+//  -------------------------------------------------------------------------
+//  Copyright (C) 2019 Daniel Werner Lima Souza de Almeida
+//  -------------------------------------------------------------------------
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//  -------------------------------------------------------------------------
+
+#ifndef PYTHONRAMSES_RAMSESOBJECT_H
+#define PYTHONRAMSES_RAMSESOBJECT_H
+
+#include <string>
+
+#include "ramses-client-api/RamsesObject.h"
+#include "ramses-client-api/RamsesObjectTypes.h"
+namespace RamsesPython
+{
+
+class RamsesObject
+{
+    public:
+        RamsesObject(ramses::RamsesObject* ramsesObject);
+        std::string getName();
+        bool isOfType(ramses::ERamsesObjectType type) const;
+        ramses::ERamsesObjectType getType() const;
+    private:
+        ramses::RamsesObject* m_object;
+
+};
+
+}
+#endif

--- a/src/include/ramses-python/Scene.h
+++ b/src/include/ramses-python/Scene.h
@@ -1,5 +1,5 @@
 //  -------------------------------------------------------------------------
-//  Copyright (C) 2019 BMW AG
+//  Copyright (C) 2019 BMW AG, Daniel Werner Lima Souza de Almeida
 //  -------------------------------------------------------------------------
 //  This Source Code Form is subject to the terms of the Mozilla Public
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -15,6 +15,7 @@
 #include "ramses-client-api/Scene.h"
 #include "ramses-client-api/RamsesClient.h"
 #include "ramses-client-api/Resource.h"
+#include "ramses-client-api/RamsesObject.h"
 
 #include "ramses-python/Resource.h"
 #include "ramses-python/TextureSampler.h"
@@ -25,6 +26,7 @@
 #include "ramses-python/RenderGroup.h"
 #include "ramses-python/RenderPass.h"
 #include "ramses-python/Camera.h"
+#include "ramses-python/RamsesObject.h"
 
 namespace boost
 {
@@ -70,6 +72,8 @@ namespace RamsesPython
 
         void saveToFiles(std::string sceneFile, std::string resourcesFile, bool compress);
         std::string getValidationReport() const;
+
+        RamsesObject findObjectByName(const char* name);
 
     private:
         ramses::Scene* m_scene;


### PR DESCRIPTION
Add binding for Scene::findObjectByName(char*) in order to facilitate object retrieval in Python.

Signed-off-by: Daniel W. S. Almeida <dwlsalmeida@gmail.com>