### PR TITLE
Add bindings for SceneGraphIterator

### DIFF
--- a/src/RamsesPython.cpp
+++ b/src/RamsesPython.cpp
@@ -8,6 +8,8 @@
 
 #include "ramses-python/RamsesPython.h"
 #include "ramses-python/Resource.h"
+#include "ramses-python/SceneGraphIterator.h"
+#include "ramses-client-api/SceneGraphIterator.h"
 
 // Needed for stl <-> python conversions - don't remove!
 #include "pybind11/stl.h"
@@ -236,4 +238,14 @@ PYBIND11_MODULE(RamsesPython, m)
         .value("ERamsesObjectType_DataVector4i",				ramses::ERamsesObjectType_DataVector4i            , "ERamsesObjectType_DataVector4i")
         .value("ERamsesObjectType_StreamTexture",               ramses::ERamsesObjectType_StreamTexture           , "ERamsesObjectType_StreamTexture")
 		.export_values();
+
+    class_<SceneGraphIterator>(m, "SceneGraphIterator")
+        .def(init<RamsesPython::Node&, ramses::ETreeTraversalStyle, ramses::ERamsesObjectType>())
+        .def("getNext", &SceneGraphIterator::getNext)
+        ;
+
+    enum_<ramses::ETreeTraversalStyle>(m, "ETreeTraversalStyle")
+        .value("ETreeTraversalStyle_DepthFirst", ramses::ETreeTraversalStyle_DepthFirst)
+        .value("ETreeTraversalStyle_BreadthFirst", ramses::ETreeTraversalStyle_BreadthFirst)
+        ;
 }

--- a/src/SceneGraphIterator.cpp
+++ b/src/SceneGraphIterator.cpp
@@ -1,0 +1,30 @@
+//  -------------------------------------------------------------------------
+//  Copyright (C) 2019 Daniel Werner Lima Souza de Almeida
+//  -------------------------------------------------------------------------
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//  -------------------------------------------------------------------------
+
+#include "ramses-python/SceneGraphIterator.h"
+#include "ramses-client-api/SceneGraphIterator.h"
+#include "ramses-client-api/RamsesObjectTypes.h"
+
+namespace RamsesPython
+{
+
+    SceneGraphIterator::SceneGraphIterator(RamsesPython::Node& startNode,
+                                           ramses::ETreeTraversalStyle traversalStyle,
+                                           ramses::ERamsesObjectType objectType)
+        :m_iter{*startNode.m_node, traversalStyle, objectType}
+    {
+
+    };
+
+    RamsesPython::Node SceneGraphIterator::getNext()
+    {
+        ramses::Node* next {m_iter.getNext()};
+        return RamsesPython::Node {next};
+    }
+
+}

--- a/src/include/ramses-python/SceneGraphIterator.h
+++ b/src/include/ramses-python/SceneGraphIterator.h
@@ -1,0 +1,34 @@
+//  -------------------------------------------------------------------------
+//  Copyright (C) 2019 Daniel Werner Lima Souza de Almeida
+//  -------------------------------------------------------------------------
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//  -------------------------------------------------------------------------
+
+#ifndef PYTHONRAMSES_SCENEGRAPHITERATOR_H
+#define PYTHONRAMSES_SCENEGRAPHITERATOR_H
+
+#include "ramses-python/Node.h"
+#include "ramses-client-api/SceneGraphIterator.h"
+#include "ramses-client-api/RamsesObjectTypes.h"
+
+namespace RamsesPython
+{
+
+    class SceneGraphIterator
+    {
+        public:
+            SceneGraphIterator(RamsesPython::Node& startNode,
+                               ramses::ETreeTraversalStyle traversalStyle,
+                               ramses::ERamsesObjectType objectType);
+
+            RamsesPython::Node getNext();
+
+        private:
+            ramses::SceneGraphIterator m_iter;
+    };
+
+}
+
+#endif


### PR DESCRIPTION
This should make it easier inspect RAMSES scene graphs on Python's side.

There's a problem though: I am unsure on how to cast nodes to their most derived type in Python, since a "RamsesPython.Node" is not very useful.

[This person](https://github.com/pybind/pybind11/issues/105) has had the same issue.