### PR TITLE
Improve bindings for ramses::Node

### DIFF
--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -6,6 +6,8 @@
 //  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //  -------------------------------------------------------------------------
 
+#include <vector>
+
 #include "ramses-python/Node.h"
 #include <assert.h>
 
@@ -46,4 +48,43 @@ namespace RamsesPython
     {
         m_node->setVisibility(visible);
     }
+
+    Node Node::getParent()
+    {
+        return Node{m_node->getParent()};
+    }
+
+    std::vector<float> Node::getRotation()
+    {
+        float x, y, z;
+        ramses::status_t success = m_node->getRotation(x, y, z);
+        assert(ramses::StatusOK == success);
+
+        return std::vector<float> {x, y, z};
+    }
+
+    std::vector<float> Node::getTranslation()
+    {
+        float x, y, z;
+        ramses::status_t success = m_node->getTranslation(x, y, z);
+        assert(ramses::StatusOK == success);
+
+        return std::vector<float> {x, y, z};
+    }
+
+    std::vector<float> Node::getScaling()
+    {
+        float x, y, z;
+        ramses::status_t success = m_node->getScaling(x, y, z);
+        assert(ramses::StatusOK == success);
+
+        return std::vector<float> {x, y, z};
+    }
+
+    bool Node::getVisibility()
+    {
+        return m_node->getVisibility();
+    }
+
+
 }

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -91,5 +91,16 @@ namespace RamsesPython
         return m_node->getVisibility();
     }
 
+    std::vector<float> Node::getModelMatrix()
+    {
+        const uint8_t matrix_sz = 16;
+        float in[matrix_sz];
+
+        ramses::status_t success = m_node->getModelMatrix(in);
+        assert(ramses::StatusOK == success);
+
+        return std::vector<float> {in, in + matrix_sz};
+    }
+
 
 }

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -51,6 +51,11 @@ namespace RamsesPython
 
     Node Node::getParent()
     {
+        ramses:: Node* parent = m_node->getParent();
+
+        if(!parent)
+            throw std::exception{};
+
         return Node{m_node->getParent()};
     }
 

--- a/src/RamsesPython.cpp
+++ b/src/RamsesPython.cpp
@@ -279,4 +279,5 @@ PYBIND11_MODULE(RamsesPython, m)
     m.def("toMesh", &RamsesPython::TypeConversions::ToMesh);
     m.def("toPerspectiveCamera", &RamsesPython::TypeConversions::ToPerspectiveCamera);
     m.def("toOrthographicCamera", &RamsesPython::TypeConversions::ToOrthographicCamera);
+    m.def("toNode", &RamsesPython::TypeConversions::ToNode);
 }

--- a/src/RamsesPython.cpp
+++ b/src/RamsesPython.cpp
@@ -99,7 +99,6 @@ PYBIND11_MODULE(RamsesPython, m)
         .def("getTranslation", &Node::getTranslation)
         .def("getScaling", &Node::getScaling)
         .def("getVisibility", &Node::getVisibility)
-        .def("addChild", &Node::addChild)
     ;
 
     class_<Mesh, Node>(m, "Mesh")

--- a/src/RamsesPython.cpp
+++ b/src/RamsesPython.cpp
@@ -94,6 +94,11 @@ PYBIND11_MODULE(RamsesPython, m)
         .def("setTranslation", &Node::setTranslation)
         .def("setScaling", &Node::setScaling)
         .def("setVisibility", &Node::addChild)
+        .def("getParent", &Node::getParent)
+        .def("getRotation", &Node::getRotation)
+        .def("getTranslation", &Node::getTranslation)
+        .def("getScaling", &Node::getScaling)
+        .def("getVisibility", &Node::getVisibility)
         .def("addChild", &Node::addChild)
     ;
 

--- a/src/RamsesPython.cpp
+++ b/src/RamsesPython.cpp
@@ -99,6 +99,7 @@ PYBIND11_MODULE(RamsesPython, m)
         .def("getTranslation", &Node::getTranslation)
         .def("getScaling", &Node::getScaling)
         .def("getVisibility", &Node::getVisibility)
+        .def("getModelMatrix", &Node::getModelMatrix)
     ;
 
     class_<Mesh, Node>(m, "Mesh")

--- a/src/include/ramses-python/Node.h
+++ b/src/include/ramses-python/Node.h
@@ -9,6 +9,8 @@
 #ifndef PYTHONRAMSES_NODE_H
 #define PYTHONRAMSES_NODE_H
 
+#include <vector>
+
 #include "ramses-client-api/Node.h"
 #include "ramses-python/RamsesObject.h"
 
@@ -25,6 +27,12 @@ namespace RamsesPython
         void setTranslation(float x, float y, float z);
         void setScaling(float x, float y, float z);
         void setVisibility(bool visible);
+
+        Node getParent();
+        std::vector<float> getRotation();
+        std::vector<float> getTranslation();
+        std::vector<float> getScaling();
+        bool getVisibility();
 
         ramses::Node* m_node;
     };

--- a/src/include/ramses-python/Node.h
+++ b/src/include/ramses-python/Node.h
@@ -34,6 +34,7 @@ namespace RamsesPython
         std::vector<float> getScaling();
         bool getVisibility();
 
+        std::vector<float> getModelMatrix();
         ramses::Node* m_node;
     };
 }

--- a/src/include/ramses-python/TypeConversions.h
+++ b/src/include/ramses-python/TypeConversions.h
@@ -52,6 +52,16 @@ namespace RamsesPython
             assert(camera != nullptr);
             return OrthographicCamera(camera);
         }
+
+        static Node ToNode(RamsesObject object)
+        {
+            assert(object.m_object != nullptr);
+            ramses::Node* node = ramses::RamsesUtils::TryConvert<ramses::Node>(*const_cast<ramses::RamsesObject*>(object.m_object));
+            // TODO rework error handling if needed
+            assert(node != nullptr);
+            return Node(node);
+        }
+
     };
 }
 


### PR DESCRIPTION
Add a type conversion to node (in TypeConversions.h) and a few getters for node attributes.