### PR TITLE
SceneGraphIterator::getNext(): throw exception to convey NULL semantics.

### DIFF
--- a/src/SceneGraphIterator.cpp
+++ b/src/SceneGraphIterator.cpp
@@ -23,8 +23,12 @@ namespace RamsesPython
 
     RamsesPython::Node SceneGraphIterator::getNext()
     {
-        ramses::Node* next {m_iter.getNext()};
-        return RamsesPython::Node {next};
+        ramses::Node* next_ptr = m_iter.getNext();
+
+        if(!next_ptr)
+            throw std::exception{};
+
+        return RamsesPython::Node {next_ptr};
     }
 
 }


### PR DESCRIPTION
C++ is a statically typed language, but Python is not. It is therefore
tricky to convey the same semantics - in which a NULL would mean the
iterator has run out of nodes - to Python code without getting into
optionals (C++17) and changing the binding API.

This solution compromises by throwing an exception instead, which gets
converted to a Python exception automatically by pybind11. Given this,
the calling Python code can catch the exception and break any loops if
applicable and the C++ code will not create objects with no underlying
RAMSES pointers, which are useless.

Signed-off-by: Daniel W. S. Almeida <dwlsalmeida@gmail.com>