### PR TITLE
Convert RAMSES errors to Python exceptions

### DIFF
--- a/src/Appearance.cpp
+++ b/src/Appearance.cpp
@@ -9,6 +9,8 @@
 #include "ramses-python/Appearance.h"
 #include "ramses-client.h"
 #include <assert.h>
+#include <string>
+#include <exception>
 
 namespace RamsesPython
 {
@@ -22,73 +24,81 @@ namespace RamsesPython
     {
         ramses::UniformInput uniform;
         ramses::status_t uniformFound = m_appearance->getEffect().findUniformInput(name.c_str(), uniform);
-        if (uniformFound == ramses::StatusOK)
+
+        if (ramses::StatusOK != uniformFound)
         {
-            switch (uniform.getDataType())
-            {
-            case ramses::EEffectInputDataType_Float:
-                assert(uniformValues.size() == uniform.getElementCount());
-                m_appearance->setInputValueFloat(uniform, uniform.getElementCount(), (uniformValues).data());
-                break;
-            case ramses::EEffectInputDataType_Vector2F:
-                assert(uniformValues.size() == uniform.getElementCount() * 2);
-                m_appearance->setInputValueVector2f(uniform, uniform.getElementCount(), (uniformValues).data());
-                break;
-            case ramses::EEffectInputDataType_Vector3F:
-                assert(uniformValues.size() == uniform.getElementCount() * 3);
-                m_appearance->setInputValueVector3f(uniform, uniform.getElementCount(), (uniformValues).data());
-                break;
-            case ramses::EEffectInputDataType_Vector4F:
-                assert(uniformValues.size() == uniform.getElementCount() * 4);
-                m_appearance->setInputValueVector4f(uniform, uniform.getElementCount(), (uniformValues).data());
-                break;
-            case ramses::EEffectInputDataType_Matrix22F:
-                assert(uniformValues.size() == uniform.getElementCount() * 4);
-                m_appearance->setInputValueMatrix22f(uniform, uniform.getElementCount(), (uniformValues).data());
-                break;
-            case ramses::EEffectInputDataType_Matrix33F:
-                assert(uniformValues.size() == uniform.getElementCount() * 9);
-                m_appearance->setInputValueMatrix33f(uniform, uniform.getElementCount(), (uniformValues).data());
-                break;
-            case ramses::EEffectInputDataType_Matrix44F:
-                assert(uniformValues.size() == uniform.getElementCount() * 16);
-                m_appearance->setInputValueMatrix44f(uniform, uniform.getElementCount(), (uniformValues).data());
-                break;
-            default:
-                assert(false && "uniform not found");
-            }
+            std::string msg {"Uniform not found!"};
+            throw std::runtime_error(msg);
         }
-        // TODO error handling
+
+        switch (uniform.getDataType())
+        {
+        case ramses::EEffectInputDataType_Float:
+            assert(uniformValues.size() == uniform.getElementCount());
+            m_appearance->setInputValueFloat(uniform, uniform.getElementCount(), (uniformValues).data());
+            break;
+        case ramses::EEffectInputDataType_Vector2F:
+            assert(uniformValues.size() == uniform.getElementCount() * 2);
+            m_appearance->setInputValueVector2f(uniform, uniform.getElementCount(), (uniformValues).data());
+            break;
+        case ramses::EEffectInputDataType_Vector3F:
+            assert(uniformValues.size() == uniform.getElementCount() * 3);
+            m_appearance->setInputValueVector3f(uniform, uniform.getElementCount(), (uniformValues).data());
+            break;
+        case ramses::EEffectInputDataType_Vector4F:
+            assert(uniformValues.size() == uniform.getElementCount() * 4);
+            m_appearance->setInputValueVector4f(uniform, uniform.getElementCount(), (uniformValues).data());
+            break;
+        case ramses::EEffectInputDataType_Matrix22F:
+            assert(uniformValues.size() == uniform.getElementCount() * 4);
+            m_appearance->setInputValueMatrix22f(uniform, uniform.getElementCount(), (uniformValues).data());
+            break;
+        case ramses::EEffectInputDataType_Matrix33F:
+            assert(uniformValues.size() == uniform.getElementCount() * 9);
+            m_appearance->setInputValueMatrix33f(uniform, uniform.getElementCount(), (uniformValues).data());
+            break;
+        case ramses::EEffectInputDataType_Matrix44F:
+            assert(uniformValues.size() == uniform.getElementCount() * 16);
+            m_appearance->setInputValueMatrix44f(uniform, uniform.getElementCount(), (uniformValues).data());
+            break;
+        default:
+            std::string msg {"Uniform not found!"};
+            throw std::runtime_error(msg);
+        }
     }
 
     void Appearance::setUniformInt(std::string name, const std::vector<int32_t>& uniformValues)
     {
         ramses::UniformInput uniform;
         ramses::status_t uniformFound = m_appearance->getEffect().findUniformInput(name.c_str(), uniform);
-        if (uniformFound == ramses::StatusOK)
+
+        if (ramses::StatusOK != uniformFound)
         {
-            switch (uniform.getDataType())
-            {
-            case ramses::EEffectInputDataType_Int32:
-                assert(uniformValues.size() == uniform.getElementCount());
-                m_appearance->setInputValueInt32(uniform, uniform.getElementCount(), (uniformValues).data());
-                break;
-            case ramses::EEffectInputDataType_Vector2I:
-                assert(uniformValues.size() == uniform.getElementCount() * 2);
-                m_appearance->setInputValueVector2i(uniform, uniform.getElementCount(), (uniformValues).data());
-                break;
-            case ramses::EEffectInputDataType_Vector3I:
-                assert(uniformValues.size() == uniform.getElementCount() * 3);
-                m_appearance->setInputValueVector3i(uniform, uniform.getElementCount(), (uniformValues).data());
-                break;
-            case ramses::EEffectInputDataType_Vector4I:
-                assert(uniformValues.size() == uniform.getElementCount() * 4);
-                m_appearance->setInputValueVector4i(uniform, uniform.getElementCount(), (uniformValues).data());
-                break;
-            default:
-                assert(false && "uniform not found");
-            }
-            // TODO error handling
+            std::string msg {"Uniform not found!"};
+            throw std::runtime_error(msg);
+        }
+
+        switch (uniform.getDataType())
+        {
+        case ramses::EEffectInputDataType_Int32:
+            assert(uniformValues.size() == uniform.getElementCount());
+            m_appearance->setInputValueInt32(uniform, uniform.getElementCount(), (uniformValues).data());
+            break;
+        case ramses::EEffectInputDataType_Vector2I:
+            assert(uniformValues.size() == uniform.getElementCount() * 2);
+            m_appearance->setInputValueVector2i(uniform, uniform.getElementCount(), (uniformValues).data());
+            break;
+        case ramses::EEffectInputDataType_Vector3I:
+            assert(uniformValues.size() == uniform.getElementCount() * 3);
+            m_appearance->setInputValueVector3i(uniform, uniform.getElementCount(), (uniformValues).data());
+            break;
+        case ramses::EEffectInputDataType_Vector4I:
+            assert(uniformValues.size() == uniform.getElementCount() * 4);
+            m_appearance->setInputValueVector4i(uniform, uniform.getElementCount(), (uniformValues).data());
+            break;
+        default:
+            std::string msg {"Expected uniform to be Int32 or Vector2I or Vector3I or Vector4I"};
+            throw std::runtime_error(msg);
         }
     }
 
@@ -96,10 +106,19 @@ namespace RamsesPython
     {
         ramses::UniformInput uniform;
         ramses::status_t uniformFound = m_appearance->getEffect().findUniformInput(name.c_str(), uniform);
-        if (uniformFound == ramses::StatusOK && uniform.getDataType() == ramses::EEffectInputDataType_TextureSampler)
+
+        if (ramses::StatusOK != uniformFound)
         {
-            m_appearance->setInputTexture(uniform, *textureSampler.m_textureSampler);
-            // TODO error handling
+            std::string msg {"Uniform not found!"};
+            throw std::runtime_error(msg);
         }
+
+        if(uniform.getDataType() != ramses::EEffectInputDataType_TextureSampler)
+        {
+            std::string msg {"Type mismatch: expected to find ramses::EEffectInputDataType_TextureSampler, but found something else."};
+            throw std::runtime_error(msg);
+        }
+
+        m_appearance->setInputTexture(uniform, *textureSampler.m_textureSampler);
     }
 }

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -7,6 +7,7 @@
 //  -------------------------------------------------------------------------
 
 #include <string>
+#include <exception>
 
 #include "ramses-python/Geometry.h"
 #include "ramses-client-api/Effect.h"
@@ -28,24 +29,37 @@ namespace RamsesPython
             m_geometry->setIndices(*ramses::RamsesUtils::TryConvert<ramses::UInt16Array>(*indexResource.m_resource));
         else if (indexResource.m_resource->getType() == ramses::ERamsesObjectType_UInt32Array)
             m_geometry->setIndices(*ramses::RamsesUtils::TryConvert<ramses::UInt32Array>(*indexResource.m_resource));
-        //TODO error handling
+        else
+        {
+            std::string msg {"Expected resource to be either ramses::ERamsesObjectType_UInt16Array or ramses::ERamsesObjectType_UInt32Array"};
+            throw std::runtime_error{msg};
+        }
+
     }
 
     void Geometry::setVertexBuffer(std::string name, Resource vertexResource)
     {
         ramses::AttributeInput attribute;
         ramses::status_t attributeFound = m_geometry->getEffect().findAttributeInput(name.c_str(), attribute);
-        if (attributeFound == ramses::StatusOK)
+
+        if (attributeFound != ramses::StatusOK)
         {
-            if (attribute.getDataType() == ramses::EEffectInputDataType_Float)
-                m_geometry->setInputBuffer(attribute, *ramses::RamsesUtils::TryConvert<ramses::FloatArray>(*vertexResource.m_resource));
-            else if (attribute.getDataType() == ramses::EEffectInputDataType_Vector2F)
-                m_geometry->setInputBuffer(attribute, *ramses::RamsesUtils::TryConvert<ramses::Vector2fArray>(*vertexResource.m_resource));
-            else if (attribute.getDataType() == ramses::EEffectInputDataType_Vector3F)
-                m_geometry->setInputBuffer(attribute, *ramses::RamsesUtils::TryConvert<ramses::Vector3fArray>(*vertexResource.m_resource));
-            else if (attribute.getDataType() == ramses::EEffectInputDataType_Vector4F)
-                m_geometry->setInputBuffer(attribute, *ramses::RamsesUtils::TryConvert<ramses::Vector4fArray>(*vertexResource.m_resource));
-            //TODO error handling
+            std::string msg {"Attribute not found!"};
+            throw std::runtime_error{msg};
+        }
+
+        if (attribute.getDataType() == ramses::EEffectInputDataType_Float)
+            m_geometry->setInputBuffer(attribute, *ramses::RamsesUtils::TryConvert<ramses::FloatArray>(*vertexResource.m_resource));
+        else if (attribute.getDataType() == ramses::EEffectInputDataType_Vector2F)
+            m_geometry->setInputBuffer(attribute, *ramses::RamsesUtils::TryConvert<ramses::Vector2fArray>(*vertexResource.m_resource));
+        else if (attribute.getDataType() == ramses::EEffectInputDataType_Vector3F)
+            m_geometry->setInputBuffer(attribute, *ramses::RamsesUtils::TryConvert<ramses::Vector3fArray>(*vertexResource.m_resource));
+        else if (attribute.getDataType() == ramses::EEffectInputDataType_Vector4F)
+            m_geometry->setInputBuffer(attribute, *ramses::RamsesUtils::TryConvert<ramses::Vector4fArray>(*vertexResource.m_resource));
+        else
+        {
+            std::string msg {"Expected attribute to be either FloatArray or Vector2fArray or Vector3fArray or Vector4fArray"};
+            throw std::runtime_error{msg};
         }
     }
 }

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -7,6 +7,9 @@
 //  -------------------------------------------------------------------------
 
 
+#include <string>
+#include <exception>
+
 #include "ramses-python/Scene.h"
 #include "ramses-python/Resource.h"
 #include "ramses-python/SceneToText.h"
@@ -88,7 +91,9 @@ namespace RamsesPython
         case 4:
             vertexResource = m_client->createConstVector4fArray(static_cast<uint32_t>(vertexData.size()) / components, (vertexData).data());
             break;
-        default: assert(false && "unsupported vertex array format");
+        default:
+            std::string msg {"Unsupported vertex array format"};
+            throw std::runtime_error {msg};
         }
 
         m_resources.push_back(vertexResource);

--- a/src/include/ramses-python/TypeConversions.h
+++ b/src/include/ramses-python/TypeConversions.h
@@ -9,6 +9,9 @@
 #ifndef PYTHONRAMSES_TYPECONVERSIONS_H
 #define PYTHONRAMSES_TYPECONVERSIONS_H
 
+#include <string>
+#include <exception>
+
 #include "ramses-client-api/MeshNode.h"
 #include "ramses-client-api/PerspectiveCamera.h"
 #include "ramses-client-api/OrthographicCamera.h"
@@ -30,8 +33,13 @@ namespace RamsesPython
         {
             assert(object.m_object != nullptr);
             ramses::MeshNode* meshNode = ramses::RamsesUtils::TryConvert<ramses::MeshNode>(*const_cast<ramses::RamsesObject*>(object.m_object));
-            // TODO rework error handling if needed
-            assert(meshNode != nullptr);
+
+            if(!meshNode)
+            {
+                std::string msg {"Cannot convert this object to a MeshNode"};
+                throw std::runtime_error{msg};
+            }
+
             return Mesh(meshNode);
         }
 
@@ -39,8 +47,13 @@ namespace RamsesPython
         {
             assert(object.m_object != nullptr);
             ramses::PerspectiveCamera* camera = ramses::RamsesUtils::TryConvert<ramses::PerspectiveCamera>(*const_cast<ramses::RamsesObject*>(object.m_object));
-            // TODO rework error handling if needed
-            assert(camera != nullptr);
+
+            if(!camera)
+            {
+                std::string msg {"Cannot convert this object to a PerspectiveCamera"};
+                throw std::runtime_error{msg};
+            }
+
             return PerspectiveCamera(camera);
         }
 
@@ -48,8 +61,13 @@ namespace RamsesPython
         {
             assert(object.m_object != nullptr);
             ramses::OrthographicCamera* camera = ramses::RamsesUtils::TryConvert<ramses::OrthographicCamera>(*const_cast<ramses::RamsesObject*>(object.m_object));
-            // TODO rework error handling if needed
-            assert(camera != nullptr);
+
+            if(!camera)
+            {
+                std::string msg {"Cannot convert this object to an OrtographicCamera"};
+                throw std::runtime_error{msg};
+            }
+
             return OrthographicCamera(camera);
         }
 
@@ -57,8 +75,13 @@ namespace RamsesPython
         {
             assert(object.m_object != nullptr);
             ramses::Node* node = ramses::RamsesUtils::TryConvert<ramses::Node>(*const_cast<ramses::RamsesObject*>(object.m_object));
-            // TODO rework error handling if needed
-            assert(node != nullptr);
+
+            if(!node)
+            {
+                std::string msg {"Cannot convert this object to Node"};
+                throw std::runtime_error{msg};
+            }
+
             return Node(node);
         }
 


### PR DESCRIPTION
As pybind11 is capable of automatically converting C++ exceptions into
Python exceptions, most asserts were replaced by them. This is relevant
because failed asserts in C++ code crash the Python interpreter, but
exceptions do not. Also noteworthy: users can figure out another approach
in the Python code itself by catching them.

Signed-off-by: Daniel W. S. Almeida <dwlsalmeida@gmail.com>