### PR TITLE
WIP: Fix for window crashing framework on close

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -13,10 +13,12 @@
 #include "Utils/Image.h"
 
 #include <vector>
+#include <thread>
+#include <cstdlib>
 
 namespace RamsesPython
 {
-    Window::Window(std::shared_ptr<ramses_display_manager::DisplayManager> displayManager, std::shared_ptr<ramses::RamsesRenderer> renderer, uint32_t width, uint32_t height, int32_t posX, int32_t posY)
+    Window::Window(ramses_display_manager::DisplayManager* displayManager, ramses::RamsesRenderer* renderer, uint32_t width, uint32_t height, int32_t posX, int32_t posY)
         : m_displayManager(displayManager)
         , m_renderer(renderer)
         , m_displayId(ramses::InvalidDisplayId)
@@ -30,8 +32,16 @@ namespace RamsesPython
             m_displayManager->dispatchAndFlush();
     }
 
-    void Window::showScene(Scene scene)
+    void Window::showScene(Scene& scene)
     {
+        //std::thread t ([&] {this->_showScene_internal(scene);});
+        //t.join();
+        _showScene_internal(scene);
+    }
+
+    void Window::_showScene_internal(Scene& scene)
+    {
+
         scene.m_scene->flush();
         scene.m_scene->publish();
 

--- a/src/include/ramses-python/RamsesPython.h
+++ b/src/include/ramses-python/RamsesPython.h
@@ -29,7 +29,7 @@ namespace RamsesPython
     {
     public:
         Ramses(std::string name);
-
+        ~Ramses();
         Scene createScene(std::string sceneName);
         Window openWindow(uint32_t width, uint32_t height, int32_t posX = 20, int32_t posY = 20);
 
@@ -37,12 +37,13 @@ namespace RamsesPython
         static ramses::RamsesFrameworkConfig& GetStaticConfig();
 
         // TODO is there a way to make class copy-able, and not use shared pointers?
-        std::shared_ptr<ramses::RamsesFramework> m_framework;
-        std::shared_ptr<ramses::RamsesClient> m_client;
-        std::shared_ptr<ramses::RamsesRenderer> m_renderer;
-        std::shared_ptr<ramses_display_manager::DisplayManager> m_displayManager;
+        ramses::RamsesFramework* m_framework = nullptr;
+        ramses::RamsesClient* m_client = nullptr;
+        ramses::RamsesRenderer* m_renderer = nullptr;
+        ramses_display_manager::DisplayManager* m_displayManager = nullptr;
 
         std::unordered_map<ramses::sceneId_t, ramses::Scene*> m_scenes;
+        std::vector<Window*> m_open_windows;
     };
 }
 

--- a/src/include/ramses-python/Window.h
+++ b/src/include/ramses-python/Window.h
@@ -19,20 +19,21 @@ namespace RamsesPython
     class Window
     {
     public:
-        Window(std::shared_ptr<ramses_display_manager::DisplayManager> displayManager, std::shared_ptr<ramses::RamsesRenderer> renderer, uint32_t width, uint32_t height, int32_t posX, int32_t posY);
+        Window(ramses_display_manager::DisplayManager* displayManager, ramses::RamsesRenderer* renderer, uint32_t width, uint32_t height, int32_t posX, int32_t posY);
 
-        void showScene(Scene scene);
+        void showScene(Scene& scene);
         void takeScreenshot(std::string file);
         void close();
 
     private:
-        std::shared_ptr<ramses_display_manager::DisplayManager> m_displayManager;
+        ramses_display_manager::DisplayManager* m_displayManager;
         // TODO Only needed for screenshots - implement feature in display manager, remove renderer reference here
-        std::shared_ptr<ramses::RamsesRenderer> m_renderer;
+        ramses::RamsesRenderer* m_renderer;
         ramses::displayId_t m_displayId;
         std::unordered_set<ramses::sceneId_t> m_shownScenes;
         const uint32_t m_width;
         const uint32_t m_height;
+        void _showScene_internal(Scene& scene);
     };
 }
 


### PR DESCRIPTION
This is meant as a discussion of the different approaches I have tried in order to solve this particular problem. 

As of now, it does not crash if we delete the call to window.close() on the Python side but closes instantly as the interpreter collects the operator object after the export is complete.

On the other hand, if we set up a breakpoint and then close the window manually, a call to exit() is made as part of calling its destructor  - i.e. ~Window_X11 on my platform. This can be attested by checking the relevant Valgrind output [here.]( https://pastebin.com/wux33jRy ) As this deletes the logger object implementing a pure virtual function, Blender crashes with "pure virtual method called".

I suggest we split the preview from the screenshot functionality. IMO screenshots can stay but opening up a window for previews should work via popen or similar approach.